### PR TITLE
Update mandelbrot.py

### DIFF
--- a/examples/threads/mandelbrot.py
+++ b/examples/threads/mandelbrot.py
@@ -87,8 +87,8 @@ class RenderThread(QtCore.QThread):
             centerY = self.centerY
             self.mutex.unlock()
 
-            halfWidth = resultSize.width() / 2
-            halfHeight = resultSize.height() / 2
+            halfWidth = int(resultSize.width() / 2)
+            halfHeight = int(resultSize.height() / 2)
             image = QtGui.QImage(resultSize, QtGui.QImage.Format_RGB32)
 
             NumPasses = 8


### PR DESCRIPTION
Fixed a float to int bug. Windows7, Python 3.3, PySide 1.1.2

Traceback (most recent call last):
  File "mandelbrot3.py", line 102, in run
    for y in range(-halfHeight, halfHeight):
TypeError: 'float' object cannot be interpreted as an integer

Fix is to cast halfHeight as int
