### PR TITLE
Update hellogl.py

### DIFF
--- a/examples/opengl/hellogl.py
+++ b/examples/opengl/hellogl.py
@@ -126,7 +126,7 @@ class GLWidget(QtOpenGL.QGLWidget):
 
     def resizeGL(self, width, height):
         side = min(width, height)
-        GL.glViewport((width - side) / 2, (height - side) / 2, side, side)
+        GL.glViewport(int((width - side) / 2),int((height - side) / 2), side, side)
 
         GL.glMatrixMode(GL.GL_PROJECTION)
         GL.glLoadIdentity()


### PR DESCRIPTION
Fixed type for python 3.x
Traceback (most recent call last):
  File "gltemp.py", line 129, in resizeGL
    GL.glViewport((width - side) / 2, (height - side) / 2, side, side)
ctypes.ArgumentError: argument 1: <class 'TypeError'>: wrong type
