### PR TITLE
QtGui has no QPoint

### DIFF
--- a/examples/itemviews/puzzle/puzzle.py
+++ b/examples/itemviews/puzzle/puzzle.py
@@ -273,7 +273,7 @@ class PiecesModel(QtCore.QAbstractListModel):
 
         while not stream.atEnd():
             pixmap = QtGui.QPixmap()
-            location = QtGui.QPoint()
+            location = QtCore.QPoint()
             stream >> pixmap >> location
 
             self.beginInsertRows(QtCore.QModelIndex(), endRow, endRow)


### PR DESCRIPTION
Changed QtGui.QPoint to QtCore.QPoint

Dragging pieces back from puzzle into list doesn't work due to incorrect module name for QPoint.
