### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/animation/easing/easing.py
+++ b/examples/animation/easing/easing.py
@@ -111,7 +111,7 @@ class Window(QtGui.QWidget):
         brush = QtGui.QBrush(gradient)
 
         # The original C++ code uses undocumented calls to get the names of the
-        # different curve types.  We do the Python equivalant (but without
+        # different curve types.  We do the Python equivalent (but without
         # cheating)
         curve_types = [(n, c) for n, c in QtCore.QEasingCurve.__dict__.items()
                         if isinstance(c, QtCore.QEasingCurve.Type) \

--- a/examples/itemviews/addressbook/addressbook.py
+++ b/examples/itemviews/addressbook/addressbook.py
@@ -74,7 +74,7 @@ class MainWindow(QMainWindow):
         toolMenu.addSeparator()
         self.removeAction = self.createAction("&Remove Entry", toolMenu, self.addressWidget.removeEntry)
         
-        # Disable the edit and remove menu items initally, as there are
+        # Disable the edit and remove menu items initially, as there are
         # no items yet.
         self.editAction.setEnabled(False)
         self.removeAction.setEnabled(False)

--- a/mobility/messaging/querymessages.py
+++ b/mobility/messaging/querymessages.py
@@ -17,7 +17,7 @@ sortOrder = QMessageSortOrder.byReceptionTimeStamp(Qt.DescendingOrder)
 # Acquire a handle to the message manager
 manager = QMessageManager()
 
-# Find the matching message IDs, limiting our results to a managable number
+# Find the matching message IDs, limiting our results to a manageable number
 matchingIds = manager.queryMessages(filter, sortOrder, 100)
 
 n = 0


### PR DESCRIPTION
There are small typos in:
- examples/animation/easing/easing.py
- examples/itemviews/addressbook/addressbook.py
- mobility/messaging/querymessages.py

Fixes:
- Should read `manageable` rather than `managable`.
- Should read `initially` rather than `initally`.
- Should read `equivalent` rather than `equivalant`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md